### PR TITLE
give up install export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,11 +24,7 @@ target_link_libraries(hsm INTERFACE tiny_tuple)
 target_include_directories(hsm INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
     )
-install(TARGETS hsm EXPORT hsm-Targets DESTINATION include)
-install(EXPORT hsm-Targets
-    NAMESPACE hsm::
-    DESTINATION lib/cmake/hsm
-    )
+
 
 if(hsm_BUILD_TESTS)
   add_subdirectory(example)


### PR DESCRIPTION
cmake requires to list all dependencies and subdependencies in the install/export set. Not possible here because we don't know them all