### PR TITLE
feat: support history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,31 @@
 
 # Changelog
 
-# [Unreleased]
+## Version 0.2.0
 In this version hsm comes with a few more bug fixes and faster state machine execution.
 So if you have no need for enter or exit actions the execution is now noticeable faster.
 Not having enter actions skips one expensive step when entering a deep hierachy.
 Not having both enter and exit actions skips the parent state entirely.
+Also history is now working - take a look at the unit test for usage. History
+is declared by adding a history assignment to a state:
+```
+   "some"_state(
+      hsm::deep_history = "first_entry"_state, // when no history is set history info will point to "first_entry"
+      // or if the deep history is not needed:
+      hsm::history = "first_entry"_state,
+      // definitions like the above cannot contain conditions or actions
+      )
+      
+   // history can be accessed via transitions, just wrap the target state with history:
+   "trigger"_ev = hsm::deep_history_of("some"_state)
+   
+   // or in case of shallow history:
+   "trigger"_ev = hsm::history_of("some"_state)
+   
+```
+
+**Feature**: history support
+- basic support is in place, error handling missing
 
 **Feature**: build system
 - move towards fetch content and simpler builds

--- a/example/alg_test.cpp
+++ b/example/alg_test.cpp
@@ -7,22 +7,25 @@
 using hsm::literals::operator""_ev;
 using hsm::literals::operator""_state;
 
-struct f{ int data{0};};
+struct f
+{
+    int data{0};
+};
 
 constexpr auto sm_with_multiple_transitions()
 {
     return hsm::create_state_machine<f>(  //
-        "e1"_ev,                       //
-        "a"_state,                     //
-        "b"_state,                     //
-        "e1"_ev = "a"_state,           //
-        "e1"_ev = "b"_state            //
+        "e1"_ev,                          //
+        "a"_state,                        //
+        "b"_state,                        //
+        "e1"_ev = "a"_state,              //
+        "e1"_ev = "b"_state               //
     );
 }
 
 TEST_CASE("Pick first matching transition", "[algorithm][transition_search]")
 {
-    f c;
+    f    c;
     auto sm = sm_with_multiple_transitions();
     sm.start(c);
     sm.process_event("e1"_ev, c);
@@ -32,16 +35,16 @@ TEST_CASE("Pick first matching transition", "[algorithm][transition_search]")
 constexpr auto sm_with_any()
 {
     return hsm::create_state_machine<f>(  //
-        "e1"_ev, "e2"_ev, "e3"_ev,     //
-        "a"_state,                     //
-        "b"_state,                     //
-        "e1"_ev  = "a"_state,          //
-        hsm::any = "b"_state           //
+        "e1"_ev, "e2"_ev, "e3"_ev,        //
+        "a"_state,                        //
+        "b"_state,                        //
+        "e1"_ev  = "a"_state,             //
+        hsm::any = "b"_state              //
     );
 }
 constexpr auto sm_with_any_internal()
 {
-    return hsm::create_state_machine<f>(         //
+    return hsm::create_state_machine<f>(      //
         "e1"_ev, "e2"_ev, "e3"_ev,            //
         hsm::initial = "a"_state,             //
         "a"_state(hsm::any = hsm::internal),  //
@@ -51,7 +54,7 @@ constexpr auto sm_with_any_internal()
 }
 TEST_CASE("Handle Any event at normal transition", "[algorithm][any][normal]")
 {
-    f c;
+    f    c;
     auto sm = sm_with_any();
     sm.start(c);
     sm.process_event("e3"_ev, c);
@@ -59,7 +62,7 @@ TEST_CASE("Handle Any event at normal transition", "[algorithm][any][normal]")
 }
 TEST_CASE("Prefer specific transition over any event transition", "[algorithm][any][normal]")
 {
-    f c;
+    f    c;
     auto sm = sm_with_any();
     sm.start(c);
     sm.process_event("e1"_ev, c);
@@ -67,7 +70,7 @@ TEST_CASE("Prefer specific transition over any event transition", "[algorithm][a
 }
 TEST_CASE("Handle Any event at internal transition", "[algorithm][any][internal]")
 {
-    f c;
+    f    c;
     auto sm = sm_with_any_internal();
     sm.start(c);
     REQUIRE(sm.current_state_id() == sm.get_state_id("a"_state));
@@ -79,38 +82,104 @@ TEST_CASE("Handle Any event at internal transition", "[algorithm][any][internal]
     REQUIRE(sm.current_state_id() == sm.get_state_id("a"_state));
 }
 
-
 constexpr auto sm_enter_exit()
 {
-    return hsm::create_state_machine<f>(         //
-        "e1"_ev,            //
-        hsm::initial = "a"_state,             //
+    return hsm::create_state_machine<f>(  //
+        "e1"_ev,                          //
+        hsm::initial = "a"_state,         //
         "a"_state(
-            hsm::enter = [](f & self){ self.data=1;},
-            hsm::exit = [](f & self){ self.data=3;},
-            "e1"_ev = "b"_state //
-            ),  //
-        "b"_state,                            //
-         "e1"_ev = "a"_state
-    );
+            hsm::enter = [](f& self) { self.data = 1; }, hsm::exit = [](f& self) { self.data = 3; },
+            "e1"_ev = "b"_state  //
+            ),                   //
+        "b"_state,               //
+        "e1"_ev = "a"_state);
 }
 
-TEST_CASE("Ëxecute Enter Actions ", "[algorithm][struct][enter]")
+TEST_CASE("Execute Enter Actions ", "[algorithm][struct][enter]")
 {
-    f c;
+    f    c;
     auto sm = sm_enter_exit();
     sm.start(c);
     REQUIRE(c.data == 1);
 }
 
-
-TEST_CASE("Ëxecute Exit Actions ", "[algorithm][struct][exit]")
+TEST_CASE("Execute Exit Actions ", "[algorithm][struct][exit]")
 {
-    f c;
+    f    c;
     auto sm = sm_enter_exit();
     sm.start(c);
     sm.process_event("e1"_ev, c);
     REQUIRE(c.data == 3);
 }
 
+constexpr auto sm_with_shallow_history()
+{
+    return hsm::create_state_machine<f>(  //
+        "e1"_ev,                          //
+        hsm::initial = "a"_state,         //
+        "a"_state(                        //
+            hsm::initial = hsm::history,
+            hsm::history = "no_history"_state,  //
+            "to_remember"_state,                //
+            "no_history"_state("ev"_ev = "to_remember"_state),
+            "e1"_ev = "b"_state         //
+            ),                          //
+        "b"_state("e1"_ev = "a"_state)  //
+    );
+}
+
+TEST_CASE("Empty history in compound", "[algorithm][history][empty]")
+{
+    f    c;
+    auto sm = sm_with_shallow_history();
+    sm.start(c);
+    REQUIRE(sm.current_state_id() == sm.get_state_id("no_history"_state));
+}
+
+TEST_CASE("Shallow History restore on initial", "[algorithm][history][shallow restore]")
+{
+    f    c;
+    auto sm = sm_with_shallow_history();
+    sm.start(c);
+    REQUIRE(sm.current_state_id() == sm.get_state_id("no_history"_state));
+    sm.process_event("ev"_ev, c); // go to remember
+    REQUIRE(sm.current_state_id() == sm.get_state_id("to_remember"_state));
+    sm.process_event("e1"_ev, c);
+    REQUIRE(sm.current_state_id() == sm.get_state_id("b"_state));
+    sm.process_event("e1"_ev, c);
+    REQUIRE(sm.current_state_id() == sm.get_state_id("to_remember"_state));
+
+}
+
+
+constexpr auto sm_with_shallow_history_of()
+{
+    return hsm::create_state_machine<f>(  //
+        "e1"_ev,                          //
+        hsm::initial = "a"_state,         //
+        "a"_state(                        //
+            hsm::initial = hsm::history,
+            hsm::history = "no_history"_state,  //
+            "to_remember"_state,                //
+            "no_history"_state("ev"_ev = "to_remember"_state),
+            "e1"_ev = "b"_state         //
+            ),                          //
+        "b"_state("e1"_ev = history_of("a"_state))  //
+    );
+}
+
+
+TEST_CASE("Shallow History restore on history_of", "[algorithm][history][shallow restore 2]")
+{
+    f    c;
+    auto sm = sm_with_shallow_history_of();
+    sm.start(c);// go to no history 
+    REQUIRE(sm.current_state_id() == sm.get_state_id("no_history"_state));
+    sm.process_event("ev"_ev, c); // go to remember
+    REQUIRE(sm.current_state_id() == sm.get_state_id("to_remember"_state));
+    sm.process_event("e1"_ev, c);
+    REQUIRE(sm.current_state_id() == sm.get_state_id("b"_state));
+    sm.process_event("e1"_ev, c);
+    REQUIRE(sm.current_state_id() == sm.get_state_id("to_remember"_state));
+}
 

--- a/example/back.cpp
+++ b/example/back.cpp
@@ -24,10 +24,11 @@ int main()
     }
     {
         using test_sm = decltype(create_state_machine<Empty>("a"_state, "e"_ev, "a"_state + "e"_ev = "a"_state));
-        static_assert(std::is_same<map<item<no_event, km::uint_<0>>,                                                          //
-                                       item<hsm::slit<'a'>, back::state<0, 1, 0, 0, 0, 0, back::transition<4, 1, 1, 0, 0>>>,  //
-                                       item<hsm::elit<'e'>, km::uint_<1>>,                                                    //
-                                       item<root_state, back::state<0, 0, 1, 0, 0, 0>>>,                                      //
+        static_assert(std::is_same<map<item<no_event, km::uint_<0>>,  //
+                                       item<back::history_table, std::integer_sequence<size_t>>,
+                                       item<hsm::slit<'a'>, back::state<0, 1, 0, 0, 0, 0, 0, back::transition<4, 1, 1, 0, 0>>>,  //
+                                       item<hsm::elit<'e'>, km::uint_<1>>,                                                       //
+                                       item<root_state, back::state<0, 0, 1, 0, 0, 0, 0>>>,                                      //
                                    typename test_sm::raw_state_machine>::value,
                       "error");
     }
@@ -44,47 +45,51 @@ int main()
 
     {
         using test_sm = decltype(create_state_machine<Empty>("a"_state, "e"_ev, "a"_state + "e"_ev = hsm::internal));
-        static_assert(
-            std::is_same<
-                map<item<no_event, km::uint_<0>>, item<hsm::slit<'a'>, back::state<0, 1, 0, 0, 0, 0, back::transition<3, 1, 1, 0, 0>>>,
-                    item<hsm::elit<'e'>, km::uint_<1>>, item<root_state, back::state<0, 0, 1, 0, 0, 0>>>,
-                typename test_sm::raw_state_machine>::value,
-            "error");
+        static_assert(std::is_same<map<item<no_event, km::uint_<0>>,                              //
+                                       item<back::history_table, std::integer_sequence<size_t>>,  //
+                                       item<hsm::slit<'a'>, back::state<0, 1, 0, 0, 0, 0, 0, back::transition<3, 1, 1, 0, 0>>>,
+                                       item<hsm::elit<'e'>, km::uint_<1>>, item<root_state, back::state<0, 0, 1, 0, 0, 0, 0>>>,
+                                   typename test_sm::raw_state_machine>::value,
+                      "error");
     }
     {
         using test_sm = decltype(create_state_machine<Empty>("a"_state, "e"_ev, "e"_ev = hsm::internal));
-        static_assert(std::is_same<map<item<no_event, km::uint_<0>>,                                                       //
-                                       item<hsm::slit<'a'>, back::state<0, 1, 0, 0, 0, 0>>,                                //
-                                       item<hsm::elit<'e'>, km::uint_<1>>,                                                 //
-                                       item<root_state, back::state<0, 0, 1, 0, 0, 0, back::transition<3, 1, 0, 0, 0>>>>,  //
+        static_assert(std::is_same<map<item<no_event, km::uint_<0>>,                                                          //
+                                       item<back::history_table, std::integer_sequence<size_t>>,                              //
+                                       item<hsm::slit<'a'>, back::state<0, 1, 0, 0, 0, 0, 0>>,                                //
+                                       item<hsm::elit<'e'>, km::uint_<1>>,                                                    //
+                                       item<root_state, back::state<0, 0, 1, 0, 0, 0, 0, back::transition<3, 1, 0, 0, 0>>>>,  //
                                    typename test_sm::raw_state_machine>::value,
                       "invalid");
     }
     {
         using test_sm = decltype(create_state_machine<Empty>("a"_state, "e"_ev, "a"_state + "e"_ev = hsm::X));
-        static_assert(std::is_same<map<item<no_event, km::uint_<0>>,                                                           //
-                                       item<hsm::slit<'a'>, back::state<0, 1, 0, 0, 0, 0, back::transition<12, 1, 0, 0, 0>>>,  //
-                                       item<hsm::elit<'e'>, km::uint_<1>>,                                                     //
-                                       item<root_state, back::state<0, 0, 1, 0, 0, 0>>>,                                       //
+        static_assert(std::is_same<map<item<no_event, km::uint_<0>>,                                                              //
+                                       item<back::history_table, std::integer_sequence<size_t>>,                                  //
+                                       item<hsm::slit<'a'>, back::state<0, 1, 0, 0, 0, 0, 0, back::transition<12, 1, 0, 0, 0>>>,  //
+                                       item<hsm::elit<'e'>, km::uint_<1>>,                                                        //
+                                       item<root_state, back::state<0, 0, 1, 0, 0, 0, 0>>>,                                       //
                                    typename test_sm::raw_state_machine>::value,
                       "invalid");
     }
     {
         using test_sm = decltype(create_state_machine<Empty>("a"_state, "e1"_ev, "e2"_ev));
-        static_assert(std::is_same<map<item<no_event, km::uint_<0>>,                    //
-                                       item<slit<'a'>, back::state<0, 1, 0, 0, 0, 0>>,  //
-                                       item<hsm::elit<'e', '1'>, km::uint_<1>>,         //
-                                       item<hsm::elit<'e', '2'>, km::uint_<2>>,         //
-                                       item<root_state, back::state<0, 0, 1, 0, 0, 0>>>,
+        static_assert(std::is_same<map<item<no_event, km::uint_<0>>,                              //
+                                       item<back::history_table, std::integer_sequence<size_t>>,  //
+                                       item<slit<'a'>, back::state<0, 1, 0, 0, 0, 0, 0>>,         //
+                                       item<hsm::elit<'e', '1'>, km::uint_<1>>,                   //
+                                       item<hsm::elit<'e', '2'>, km::uint_<2>>,                   //
+                                       item<root_state, back::state<0, 0, 1, 0, 0, 0, 0>>>,
                                    typename test_sm::raw_state_machine>::value,
                       "invalid");
     }
 
     {
         using test_sm = decltype(create_state_machine<Empty>("e1"_ev));
-        static_assert(std::is_same<map<item<no_event, km::uint_<0>>,             //
-                                       item<hsm::elit<'e', '1'>, km::uint_<1>>,  //
-                                       item<root_state, back::state<0, 0, 0, 0, 0, 0>>>,
+        static_assert(std::is_same<map<item<no_event, km::uint_<0>>,                              //
+                                       item<back::history_table, std::integer_sequence<size_t>>,  //
+                                       item<hsm::elit<'e', '1'>, km::uint_<1>>,                   //
+                                       item<root_state, back::state<0, 0, 0, 0, 0, 0, 0>>>,
                                    typename test_sm::raw_state_machine>::value,
                       "invalid");
     }
@@ -92,9 +97,10 @@ int main()
         auto a1       = [](Empty&) {};
         using test_sm = decltype(create_state_machine<Empty>("a"_state(), hsm::enter = a1));
         static_assert(
-            std::is_same<map<item<no_event, km::uint_<0>>,  //
-                             item<hsm::slit<'a'>, back::state<0, 1, 0, 0, 0, 0>>,
-                             item<root_state, back::state<static_cast<uint32_t>(back::state_flags::has_entry), 0, 1, 0, 0, 0>>>,
+            std::is_same<map<item<no_event, km::uint_<0>>,                              //
+                             item<back::history_table, std::integer_sequence<size_t>>,  //
+                             item<hsm::slit<'a'>, back::state<0, 1, 0, 0, 0, 0, 0>>,
+                             item<root_state, back::state<static_cast<uint32_t>(back::state_flags::has_entry), 0, 1, 0, 0, 0, 0>>>,
                          typename test_sm::raw_state_machine>::value,
             "invalid");
     }
@@ -102,9 +108,11 @@ int main()
         auto a1       = [](Empty&) {};
         using test_sm = decltype(create_state_machine<Empty>("a"_state(), hsm::exit = a1, hsm::enter = a1));
         static_assert(
-            std::is_same<map<item<no_event, km::uint_<0>>,  //
-                             item<hsm::slit<'a'>, back::state<0, 1, 0, 0, 0, 0>>,
-                             item<root_state, back::state<static_cast<uint32_t>(back::state_flags::has_entry | back::state_flags::has_exit), 0, 1, 0, 1, 0>>>,
+            std::is_same<map<item<no_event, km::uint_<0>>,                              //
+                             item<back::history_table, std::integer_sequence<size_t>>,  //
+                             item<hsm::slit<'a'>, back::state<0, 1, 0, 0, 0, 0, 0>>,
+                             item<root_state, back::state<static_cast<uint32_t>(back::state_flags::has_entry | back::state_flags::has_exit),
+                                                          0, 1, 0, 1, 0, 0>>>,
                          typename test_sm::raw_state_machine>::value,
             "invalid");
     }
@@ -112,10 +120,106 @@ int main()
         auto a1       = [](Empty&) {};
         using test_sm = decltype(create_state_machine<Empty>("a"_state(hsm::enter = a1)));
         static_assert(
-            std::is_same<map<item<no_event, km::uint_<0>>,  //
-                             item<hsm::slit<'a'>, back::state<static_cast<uint32_t>(back::state_flags::has_entry), 1, 0, 0, 0, 0>>,
-                             item<root_state, back::state<0, 0, 1, 0, 0, 0>>>,
+            std::is_same<map<item<no_event, km::uint_<0>>,                              //
+                             item<back::history_table, std::integer_sequence<size_t>>,  //
+                             item<hsm::slit<'a'>, back::state<static_cast<uint32_t>(back::state_flags::has_entry), 1, 0, 0, 0, 0, 0>>,
+                             item<root_state, back::state<0, 0, 1, 0, 0, 0, 0>>>,
                          typename test_sm::raw_state_machine>::value,
+            "invalid");
+    }
+    {
+        auto a1       = [](Empty&) {};
+        using test_sm = decltype(create_state_machine<Empty>("a"_state(hsm::history = "b"_state, "b"_state)));
+        static_assert(
+            std::is_same<map<item<no_event, km::uint_<0>>,                                 //
+                             item<back::history_table, std::integer_sequence<size_t, 2>>,  //
+                             item<hsm::slit<'b'>, back::state<0, 2, 0, 1, 0, 0, 0>>,
+                             item<hsm::slit<'a'>, back::state<static_cast<uint32_t>(back::state_flags::has_history), 1, 1, 0, 0, 0, 0>>,
+                             item<root_state, back::state<0, 0, 2, 0, 0, 0, 0>>>,
+                         typename test_sm::raw_state_machine>::value,
+            "invalid");
+    }
+    {
+        auto a1       = [](Empty&) {};
+        using test_sm = decltype(create_state_machine<Empty>("a"_state(hsm::deep_history = "b"_state, "b"_state)));
+
+        static_assert(
+            std::is_same<
+                map<item<no_event, km::uint_<0>>,                                 //
+                    item<back::history_table, std::integer_sequence<size_t, 2>>,  //
+                    item<hsm::slit<'b'>, back::state<0, 2, 0, 1, 0, 0, 0>>,
+                    item<hsm::slit<'a'>, back::state<static_cast<uint32_t>(back::state_flags::has_deep_history), 1, 1, 0, 0, 0, 0>>,
+                    item<root_state, back::state<0, 0, 2, 0, 0, 0, 0>>>,
+                typename test_sm::raw_state_machine>::value,
+            "invalid");
+    }
+    {
+        using test_sm                   = decltype(create_state_machine<Empty>(  //
+            "a"_state, "ee"_ev = deep_history_of("a"_state)));
+        constexpr size_t state_a        = 1;
+        constexpr size_t ee_event       = 1;
+        constexpr size_t has_no_history = 0;  //! yes the state machine definition is broken
+        static_assert(
+            std::is_same<map<item<no_event, km::uint_<0>>,                                               //
+                             item<back::history_table, std::integer_sequence<size_t>>,                   //
+                             item<hsm::slit<'a'>, back::state<has_no_history, state_a, 0, 0, 0, 0, 0>>,  //
+                             item<hsm::elit<'e', 'e'>, kvasir::mpl::uint_<ee_event>>,                    //
+                             item<root_state, back::state<0, 0, 1, 0, 0, 0, 0,
+                                                          back::transition<static_cast<uint8_t>(back::transition_flags::to_deep_history |
+                                                                                                back::transition_flags::normal),
+                                                                           ee_event, state_a, 0, 0>>>>,
+                         typename test_sm::raw_state_machine>::value,
+            "invalid");
+    }
+    {
+        using test_sm                   = decltype(create_state_machine<Empty>(  //
+            "a"_state, "ee"_ev = history_of("a"_state)));
+        constexpr size_t state_a        = 1;
+        constexpr size_t ee_event       = 1;
+        constexpr size_t has_no_history = 0;  //! yes the state machine definition is broken
+        static_assert(
+            std::is_same<map<item<no_event, km::uint_<0>>,                                               //
+                             item<back::history_table, std::integer_sequence<size_t>>,                   //
+                             item<hsm::slit<'a'>, back::state<has_no_history, state_a, 0, 0, 0, 0, 0>>,  //
+                             item<hsm::elit<'e', 'e'>, kvasir::mpl::uint_<ee_event>>,                    //
+                             item<root_state, back::state<0, 0, 1, 0, 0, 0, 0,
+                                                          back::transition<static_cast<uint8_t>(back::transition_flags::to_shallow_history |
+                                                                                                back::transition_flags::normal),
+                                                                           ee_event, state_a, 0, 0>>>>,
+                         typename test_sm::raw_state_machine>::value,
+            "invalid");
+    }
+    {
+        using test_sm             = decltype(create_state_machine<Empty>(  //
+            "a"_state("ee"_ev = hsm::X)));
+        constexpr size_t state_a  = 1;
+        constexpr size_t ee_event = 1;
+
+        static_assert(
+            std::is_same<map<item<no_event, km::uint_<0>>,                              //
+                             item<back::history_table, std::integer_sequence<size_t>>,  //
+                             item<hsm::elit<'e', 'e'>, kvasir::mpl::uint_<ee_event>>,   //
+                             item<hsm::slit<'a'>, back::state<0, state_a, 0, 0, 0, 0, 0,
+                                                              back::transition<static_cast<uint8_t>(back::transition_flags::to_final |
+                                                                                                    back::transition_flags::normal),
+                                                                               ee_event, state_a, 0, 0>>>,  //
+                             item<root_state, back::state<0, 0, 1, 0, 0, 0, 0>>>,
+                         typename test_sm::raw_state_machine>::value,
+            "invalid");
+    }
+    {
+        auto a1 = [](Empty&) {};
+        using test_sm =
+            decltype(create_state_machine<Empty>("a"_state(hsm::deep_history = "b"_state, "b"_state(hsm::history = "c"_state, "c"_state))));
+        static_assert(
+            std::is_same<
+                map<item<no_event, km::uint_<0>>,                                    //
+                    item<back::history_table, std::integer_sequence<size_t, 2, 3>>,  //
+                    item<hsm::slit<'c'>, back::state<0, 3, 0, 2, 0, 0, 0>>,
+                    item<hsm::slit<'b'>, back::state<static_cast<uint32_t>(back::state_flags::has_history), 2, 1, 1, 0, 0, 1>>,
+                    item<hsm::slit<'a'>, back::state<static_cast<uint32_t>(back::state_flags::has_deep_history), 1, 2, 0, 0, 0, 0>>,
+                    item<root_state, back::state<0, 0, 3, 0, 0, 0, 0>>>,
+                typename test_sm::raw_state_machine>::value,
             "invalid");
     }
 }

--- a/example/sort_test.cpp
+++ b/example/sort_test.cpp
@@ -47,10 +47,10 @@ int main()
     }
 
     {
-        using type = hb::state<49u, 0ul, 1ul, 0ul, 4ul, 5ul, hsm::back::transition<0u, 0ul, 3ul, 0ul, 0ul>,
+        using type = hb::state<49u, 0ul, 1ul, 0ul, 4ul, 5ul, 0ul, hsm::back::transition<0u, 0ul, 3ul, 0ul, 0ul>,
                                hsm::back::transition<4 | 32, 2ul, 5ul, 0ul, 9ul>>;
 
-        using se      = hsm::detail::state_entry<unsigned char, unsigned char, unsigned char>;
+        using se      = hsm::detail::state_entry<unsigned char, unsigned char, unsigned char, unsigned char>;
         se const* sts = hsm::back::get_state_table<se>(kvasir::mpl::list<type>{});
         if (sts[0].transition_count == 2 && sts[0].special_transition_count == 1) { std::cout << "success\n"; }
         else

--- a/include/hsm/detail/back.hpp
+++ b/include/hsm/detail/back.hpp
@@ -53,6 +53,12 @@ struct get_state_impl<C, hsm::internal_transition>
     using type = C;
 };
 
+template <typename C, typename T>
+struct get_state_impl<C, hsm::state_ref<T>>
+{
+    using type = T;
+};
+
 template <typename C>
 struct get_state_impl<C, hsm::initial_state>
 {
@@ -153,8 +159,8 @@ struct is_state
     struct f_impl : kvasir::mpl::bool_<false>
     {
     };
-    template <typename N, uint32_t F, size_t S, size_t P, size_t Entry, size_t Exit, typename... Ts>
-    struct f_impl<tiny_tuple::detail::item<N, hsm::back::state<F, Id, S, P, Entry, Exit, Ts...>>> : kvasir::mpl::bool_<true>
+    template <typename N, uint32_t F, size_t S, size_t P, size_t Entry, size_t Exit, size_t H, typename... Ts>
+    struct f_impl<tiny_tuple::detail::item<N, hsm::back::state<F, Id, S, P, Entry, Exit, H, Ts...>>> : kvasir::mpl::bool_<true>
     {
     };
     template <typename T>
@@ -167,8 +173,8 @@ struct is_any_state
     struct f_impl : kvasir::mpl::bool_<false>
     {
     };
-    template <typename N, uint32_t F, size_t Id, size_t S, size_t P, size_t Entry, size_t Exit, typename... Ts>
-    struct f_impl<tiny_tuple::detail::item<N, hsm::back::state<F, Id, S, P, Entry, Exit, Ts...>>> : kvasir::mpl::bool_<true>
+    template <typename N, uint32_t F, size_t Id, size_t S, size_t P, size_t Entry, size_t Exit, size_t H, typename... Ts>
+    struct f_impl<tiny_tuple::detail::item<N, hsm::back::state<F, Id, S, P, Entry, Exit, H, Ts...>>> : kvasir::mpl::bool_<true>
     {
     };
     template <typename T>

--- a/include/hsm/detail/hsm.hpp
+++ b/include/hsm/detail/hsm.hpp
@@ -31,11 +31,12 @@ struct get_id_type_impl<Count, std::enable_if_t<(Count >= 0 && Count < 255)>>
     using type = uint8_t;
 };
 
-template <typename StateId, typename TTOffset, typename ActionId>
+template <typename StateId, typename TTOffset, typename ActionId, typename HistoryId>
 struct state_entry
 {
     using action_id                    = ActionId;
     using state_id                     = StateId;
+    using history_id                   = HistoryId;
     using transition_table_offset_type = TTOffset;
     TTOffset          transition_table_offset{0};
     action_id         enter_action{0};
@@ -45,6 +46,7 @@ struct state_entry
     uint16_t          transition_count{0};
     uint8_t           special_transition_count{0};
     back::state_flags flags{back::state_flags::none};
+    history_id        history{0};
 
     constexpr bool has_default() const { return is_set(flags, back::state_flags::has_default_transition); }
 
@@ -72,7 +74,8 @@ struct tt_entry
     constexpr back::transition_flags transition_type() const { return flags & back::transition_flags::transition_type_mask; }
 
     constexpr back::transition_flags destination_type() const { return flags & back::transition_flags::dest_mask; }
-    constexpr bool to_history() const { return is_set(destination_type(), back::transition_flags::to_shallow_history); }
+    constexpr bool to_shallow_history() const { return is_set(destination_type(), back::transition_flags::to_shallow_history); }
+    constexpr bool to_deep_history() const { return is_set(destination_type(), back::transition_flags::to_shallow_history); }
     constexpr bool to_final() const { return is_set(destination_type(), back::transition_flags::to_final); }
     constexpr bool has_action() const { return back::transition_flags::has_action == (flags & back::transition_flags::has_action); }
     constexpr bool has_condition() const

--- a/include/hsm/hsm_fwd.hpp
+++ b/include/hsm/hsm_fwd.hpp
@@ -45,7 +45,7 @@ struct action_node;
 namespace back
 {
 constexpr size_t any_event_id = 0;
-template <uint32_t Flags, size_t Id, size_t Size, size_t ParentId, size_t Entry, size_t Exit, typename... Transitions>
+template <uint32_t Flags, size_t Id, size_t Size, size_t ParentId, size_t Entry, size_t Exit, size_t History, typename... Transitions>
 struct state;
 
 template <uint32_t Flags, size_t E, size_t D, size_t C, size_t A>


### PR DESCRIPTION
not all possible configuration errors are detected - i.e. having both deep and shallow history is not detected, nor if somone has no history defined but tries to access it.